### PR TITLE
Add Noroff Duty Schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
               <a href="https://content.noroff.dev/" class="list-group-item list-group-item-action">Noroff Content System</a>
               <a href="https://cors.noroff.dev/" class="list-group-item list-group-item-action">Noroff CORS Anywhere</a>
               <a href="https://rename.noroff.dev/" class="list-group-item list-group-item-action">Noroff Rename (by Kyrre)</a>
+              <a href="https://duty.noroff.dev/" class="list-group-item list-group-item-action">Noroff Duty Schedule (by Bjørnar)</a>
               <a href="forms" class="list-group-item list-group-item-action">Noroff Student Forms</a>
             </div>
           </div>


### PR DESCRIPTION
This pull request adds the Noroff Duty Schedule feature to the Noroff website. Users can now access the Duty Schedule by visiting the link provided.